### PR TITLE
Refactor propagator for testability and add unit tests

### DIFF
--- a/cmd/firesync/main.go
+++ b/cmd/firesync/main.go
@@ -128,7 +128,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 
-	propagator := service.NewPropagator(pubsubClient.Topic(cfg.Topic), firestoreClient, cfg.TombstoneTTL, meter)
+	propagator := service.NewPropagator(service.NewPubSubTopicAdapter(pubsubClient.Topic(cfg.Topic)), service.NewFirestoreClientAdapter(firestoreClient), cfg.TombstoneTTL, meter)
 	replicator := service.NewReplicator(meter, firestoreClient)
 
 	r := router.New(router.Config{

--- a/internal/model/docname.go
+++ b/internal/model/docname.go
@@ -62,6 +62,12 @@ func (d *DocumentName) TombstoneRef(db *firestore.Client) *firestore.DocumentRef
 	return db.Collection(TombstoneCollection).Doc(TombstoneID(d.Path))
 }
 
+// TombstonePath returns the path for the tombstone document corresponding to the
+// document name.
+func (d *DocumentName) TombstonePath() string {
+	return fmt.Sprintf("%s/%s", TombstoneCollection, TombstoneID(d.Path))
+}
+
 func (d *DocumentName) String() string {
 	return fmt.Sprintf("projects/%s/databases/%s/documents/%s", d.ProjectID, d.DatabaseID, d.Path)
 }

--- a/internal/service/firestore.go
+++ b/internal/service/firestore.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+// FirestoreClient defines the subset of Firestore functionality required by the
+// propagator. It is satisfied by the real Firestore client and can be mocked in
+// tests.
+type FirestoreClient interface {
+	RunTransaction(ctx context.Context, f func(context.Context, Transaction) error) error
+	Doc(path string) *firestore.DocumentRef
+}
+
+// Transaction represents a Firestore transaction. Implementations should
+// provide the minimal operations used by the propagator.
+type Transaction interface {
+	Get(path string) (DocumentSnapshot, error)
+	Update(path string, updates []Update, ts time.Time) error
+	Delete(path string, ts time.Time) error
+	Create(path string, data interface{}) error
+}
+
+// DocumentSnapshot is a wrapper around Firestore's DocumentSnapshot allowing it
+// to be mocked in tests.
+type DocumentSnapshot interface {
+	Exists() bool
+	DataTo(interface{}) error
+}
+
+// Update mirrors firestore.Update but allows us to decouple from the Firestore
+// client in tests.
+type Update struct {
+	Path  string
+	Value interface{}
+}
+
+// firestoreClientAdapter adapts the real firestore.Client to FirestoreClient.
+type firestoreClientAdapter struct{ *firestore.Client }
+
+// NewFirestoreClientAdapter wraps a firestore.Client so it can be consumed by
+// the propagator.
+func NewFirestoreClientAdapter(c *firestore.Client) FirestoreClient {
+	if c == nil {
+		return nil
+	}
+	return &firestoreClientAdapter{c}
+}
+
+func (c *firestoreClientAdapter) RunTransaction(ctx context.Context, f func(context.Context, Transaction) error) error {
+	return c.Client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		return f(ctx, &transactionAdapter{Transaction: tx, client: c.Client})
+	})
+}
+
+func (c *firestoreClientAdapter) Doc(path string) *firestore.DocumentRef { return c.Client.Doc(path) }
+
+// transactionAdapter adapts firestore.Transaction to our Transaction interface.
+type transactionAdapter struct {
+	*firestore.Transaction
+	client *firestore.Client
+}
+
+func (t *transactionAdapter) Get(path string) (DocumentSnapshot, error) {
+	snap, err := t.Transaction.Get(t.client.Doc(path))
+	if err != nil {
+		return nil, err
+	}
+	return &documentSnapshotAdapter{snap}, nil
+}
+
+func (t *transactionAdapter) Update(path string, updates []Update, ts time.Time) error {
+	fsUpdates := make([]firestore.Update, len(updates))
+	for i, u := range updates {
+		fsUpdates[i] = firestore.Update{Path: u.Path, Value: u.Value}
+	}
+	return t.Transaction.Update(t.client.Doc(path), fsUpdates, firestore.LastUpdateTime(ts))
+}
+
+func (t *transactionAdapter) Delete(path string, ts time.Time) error {
+	return t.Transaction.Delete(t.client.Doc(path), firestore.LastUpdateTime(ts))
+}
+
+func (t *transactionAdapter) Create(path string, data interface{}) error {
+	return t.Transaction.Create(t.client.Doc(path), data)
+}
+
+// documentSnapshotAdapter adapts firestore.DocumentSnapshot to our interface.
+type documentSnapshotAdapter struct{ *firestore.DocumentSnapshot }
+
+func (s *documentSnapshotAdapter) Exists() bool { return s.DocumentSnapshot.Exists() }
+
+func (s *documentSnapshotAdapter) DataTo(v interface{}) error { return s.DocumentSnapshot.DataTo(v) }

--- a/internal/service/propagator_test.go
+++ b/internal/service/propagator_test.go
@@ -1,0 +1,260 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"cloud.google.com/go/pubsub"
+	"github.com/googleapis/google-cloudevents-go/cloud/firestoredata"
+	"github.com/joaopenteado/firesync/internal/model"
+	"go.opentelemetry.io/otel/metric/noop"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ---- Mocks ----
+
+type mockTopic struct {
+	msg    *pubsub.Message
+	result PublishResult
+}
+
+func (m *mockTopic) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
+	m.msg = msg
+	if m.result == nil {
+		m.result = &mockResult{id: "id"}
+	}
+	return m.result
+}
+
+type mockResult struct {
+	id  string
+	err error
+}
+
+func (r *mockResult) Get(ctx context.Context) (string, error) { return r.id, r.err }
+
+type mockFirestore struct {
+	tx  Transaction
+	err error
+}
+
+func (m *mockFirestore) RunTransaction(ctx context.Context, f func(context.Context, Transaction) error) error {
+	if m.err != nil {
+		return m.err
+	}
+	return f(ctx, m.tx)
+}
+
+func (m *mockFirestore) Doc(p string) *firestore.DocumentRef { return &firestore.DocumentRef{Path: p} }
+
+type mockTx struct {
+	get    func(string) (DocumentSnapshot, error)
+	update func(string, []Update, time.Time) error
+	delete func(string, time.Time) error
+	create func(string, interface{}) error
+}
+
+func (m *mockTx) Get(p string) (DocumentSnapshot, error) {
+	if m.get != nil {
+		return m.get(p)
+	}
+	return nil, status.Error(codes.NotFound, "not found")
+}
+func (m *mockTx) Update(p string, u []Update, ts time.Time) error {
+	if m.update != nil {
+		return m.update(p, u, ts)
+	}
+	return nil
+}
+func (m *mockTx) Delete(p string, ts time.Time) error {
+	if m.delete != nil {
+		return m.delete(p, ts)
+	}
+	return nil
+}
+func (m *mockTx) Create(p string, data interface{}) error {
+	if m.create != nil {
+		return m.create(p, data)
+	}
+	return nil
+}
+
+type mockSnap struct {
+	exists bool
+	data   interface{}
+	err    error
+}
+
+func (s *mockSnap) Exists() bool { return s.exists }
+
+func (s *mockSnap) DataTo(dst interface{}) error {
+	if s.err != nil {
+		return s.err
+	}
+	dv := reflect.ValueOf(dst)
+	dv.Elem().Set(reflect.ValueOf(s.data).Elem())
+	return nil
+}
+
+// helper to create event
+var defaultName = model.DocumentName{ProjectID: "p", DatabaseID: "d", Path: "users/1"}
+
+func sampleEvent(typ model.EventType, ts time.Time) *model.Event {
+	return &model.Event{
+		Type:      typ,
+		Name:      defaultName,
+		Timestamp: ts,
+		Data:      &firestoredata.DocumentEventData{Value: &firestoredata.Document{Name: defaultName.String()}},
+	}
+}
+
+// ---- Tests ----
+
+func TestPropagate_SkipTypes(t *testing.T) {
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{}, time.Second, noop.Meter{})
+	for _, typ := range []model.EventType{model.EventTypeReplicated, model.EventTypeTombstone} {
+		evt := sampleEvent(typ, time.Now())
+		res, err := svc.Propagate(context.Background(), evt)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if res != PropagationResultSkipped {
+			t.Fatalf("result = %v, want skipped", res)
+		}
+	}
+}
+
+func TestPropagate_CreateSuccess(t *testing.T) {
+	topic := &mockTopic{result: &mockResult{id: "1"}}
+	tx := &mockTx{
+		get:    func(string) (DocumentSnapshot, error) { return &mockSnap{exists: false}, nil },
+		update: func(p string, u []Update, ts time.Time) error { return nil },
+	}
+	svc := NewPropagator(topic, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeCreated, time.Now())
+	res, err := svc.Propagate(context.Background(), evt)
+	if err != nil || res != PropagationResultSuccess {
+		t.Fatalf("res=%v err=%v", res, err)
+	}
+	if topic.msg == nil {
+		t.Fatalf("message not published")
+	}
+}
+
+func TestPropagate_ProcessError(t *testing.T) {
+	tx := &mockTx{get: func(string) (DocumentSnapshot, error) { return nil, errors.New("get err") }}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeCreated, time.Now())
+	res, err := svc.Propagate(context.Background(), evt)
+	if err == nil || res != PropagationResultError {
+		t.Fatalf("expected error")
+	}
+}
+
+// processCreateEvent tests
+func TestProcessCreateEvent_TombstoneNewer(t *testing.T) {
+	tomb := &model.Tombstone{Timestamp: timestamppb.New(time.Unix(2, 0))}
+	tx := &mockTx{
+		get:    func(p string) (DocumentSnapshot, error) { return &mockSnap{exists: true, data: tomb}, nil },
+		delete: func(p string, ts time.Time) error { return nil },
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeCreated, time.Unix(1, 0))
+	ok, err := svc.processCreateEvent(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if ok {
+		t.Fatalf("should not propagate")
+	}
+}
+
+func TestProcessCreateEvent_Update(t *testing.T) {
+	tx := &mockTx{
+		get:    func(string) (DocumentSnapshot, error) { return &mockSnap{exists: false}, nil },
+		update: func(p string, u []Update, ts time.Time) error { return nil },
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeCreated, time.Unix(1, 0))
+	ok, err := svc.processCreateEvent(context.Background(), evt)
+	if err != nil || !ok {
+		t.Fatalf("want propagate true err nil got %v %v", ok, err)
+	}
+}
+
+// processUpdateEvent
+func TestProcessUpdateEvent_TombstoneNewer(t *testing.T) {
+	tomb := &model.Tombstone{Timestamp: timestamppb.New(time.Unix(2, 0))}
+	tx := &mockTx{
+		get:    func(string) (DocumentSnapshot, error) { return &mockSnap{exists: true, data: tomb}, nil },
+		delete: func(p string, ts time.Time) error { return nil },
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeUpdated, time.Unix(1, 0))
+	ok, err := svc.processUpdateEvent(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if ok {
+		t.Fatalf("should not propagate")
+	}
+}
+
+func TestProcessUpdateEvent_Update(t *testing.T) {
+	tx := &mockTx{
+		get:    func(string) (DocumentSnapshot, error) { return &mockSnap{exists: false}, nil },
+		update: func(p string, u []Update, ts time.Time) error { return nil },
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeUpdated, time.Unix(1, 0))
+	ok, err := svc.processUpdateEvent(context.Background(), evt)
+	if err != nil || !ok {
+		t.Fatalf("want propagate true err nil got %v %v", ok, err)
+	}
+}
+
+// processDeleteEvent
+func TestProcessDeleteEvent_Create(t *testing.T) {
+	tx := &mockTx{
+		get: func(p string) (DocumentSnapshot, error) {
+			if p == defaultName.Path {
+				return &mockSnap{exists: false}, nil
+			}
+			return &mockSnap{exists: false}, nil
+		},
+		create: func(p string, data interface{}) error { return nil },
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeDeleted, time.Unix(1, 0))
+	ok, err := svc.processDeleteEvent(context.Background(), evt)
+	if err != nil || !ok {
+		t.Fatalf("want propagate true got %v %v", ok, err)
+	}
+}
+
+func TestProcessDeleteEvent_TombstoneNewer(t *testing.T) {
+	tomb := &model.Tombstone{Timestamp: timestamppb.New(time.Unix(2, 0))}
+	tx := &mockTx{
+		get: func(p string) (DocumentSnapshot, error) {
+			if p == defaultName.TombstonePath() {
+				return &mockSnap{exists: true, data: tomb}, nil
+			}
+			return &mockSnap{exists: false}, nil
+		},
+	}
+	svc := NewPropagator(&mockTopic{}, &mockFirestore{tx: tx}, time.Second, noop.Meter{})
+	evt := sampleEvent(model.EventTypeDeleted, time.Unix(1, 0))
+	ok, err := svc.processDeleteEvent(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if ok {
+		t.Fatalf("should not propagate")
+	}
+}

--- a/internal/service/pubsub.go
+++ b/internal/service/pubsub.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"cloud.google.com/go/pubsub"
+	"context"
+)
+
+// PublishResult represents the result of a Pub/Sub publish operation.
+type PublishResult interface {
+	Get(context.Context) (string, error)
+}
+
+// PubSubTopic abstracts a Pub/Sub topic.
+type PubSubTopic interface {
+	Publish(context.Context, *pubsub.Message) PublishResult
+}
+
+// NewPubSubTopicAdapter wraps a pubsub.Topic so it satisfies the PubSubTopic
+// interface.
+func NewPubSubTopicAdapter(t *pubsub.Topic) PubSubTopic {
+	if t == nil {
+		return nil
+	}
+	return &pubsubTopicAdapter{t}
+}
+
+type pubsubTopicAdapter struct{ *pubsub.Topic }
+
+func (t *pubsubTopicAdapter) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
+	return t.Topic.Publish(ctx, msg)
+}


### PR DESCRIPTION
## Summary
- Introduce Firestore and Pub/Sub interfaces with adapters for propagator
- Add tombstone path helper and refactor propagator to use interfaces
- Cover propagator logic with comprehensive unit tests
- Create document references via Firestore adapter instead of manual instantiation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68901586dbac8327bbab0ba8ad5414c8